### PR TITLE
Use openjdk:8-alpine as base Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN sbt assembly
 
 
 # Open JDK 8 - Alpine
-FROM java:openjdk-8-alpine
+FROM openjdk:8-alpine
 LABEL maintainer="Ryo Ota <nwtgck@gmail.com>"
 
 # Make directories


### PR DESCRIPTION
## Changed
*  Use `openjdk:8-alpine` as base Docker image instead of "java:openjdk-8-alpine"

## Benefits
* Smaller image (smaller is better!)
* Well documented (maybe maintained well)
  - [openjdk](https://hub.docker.com/_/openjdk/): well documented
  - [java](https://hub.docker.com/_/java/?tab=description): no desciption